### PR TITLE
Add support for Japanese title in treetable

### DIFF
--- a/bin/treetable
+++ b/bin/treetable
@@ -396,6 +396,7 @@ __END__
 \documentclass[a4j,dvipdfmx,landscape]{jsarticle}
 \usepackage{longtable}
 \usepackage{hyperref}
+\usepackage{pxjahyper}
 \usepackage{multirow}
 
 \tolerance=1000


### PR DESCRIPTION
treetable を用いて tex ->pdf を生成したとき，日本語のタイトルの文字が化ける．
そこで，日本語の PDF ファイル作成を支援する pxjahyper パッケージを treetable に導入し，上記の問題を解決できた．