### PR TITLE
Add list-nompedia command 

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,8 @@
 
   + [[#treetable][treetable]] :: Convert markdown or org-mode style section tree into table.
                  It is supposed to be used for conversion of issue list into table.
+
+  + [[#list-nomladia][list-nompedia]] :: List titles and URLs of all nompedia pages
 * Descriptions
 
 ** ame
@@ -137,3 +139,7 @@
    : Usage: treetable sample-todo-list.{md|org} > sample-todo-list.tex
    For details about input-file format, check [[file:examples/treetable/todo-list.org][examples/treetable/todo-list.org]] or  [[file:examples/treetable/todo-list.md][examples/treetable/todo-list.md]].
    See also about output example [[file:examples/treetable/todo-list.pdf][examples/treetable/todo-list.pdf]]
+
+** list-nompedia
+   : Usage: list-nompedia nompedia.json
+   nompedia.json can be downloaded from [[https://scrapbox.io/projects/nompedia/settings/page-data][nompedia settings page]]

--- a/bin/list-nompedia
+++ b/bin/list-nompedia
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+NOMPEDIA_URL="https://scrapbox.io/nompedia/"
+
+function usage() {
+cat << EOS
+list-nompedia
+
+Description:
+    Display titles and URL of all nompedia pages
+Usage:
+    list-nompedia [json_file]
+Help:
+    [json_file] can be downloaded from Scrapbox settings page
+EOS
+}
+
+if [ "$1" = "" ]; then
+    usage
+    exit 1
+fi
+
+cat $1 | jq -r '.pages[].title' | sed 's/ /_/g' |  awk -v url="$NOMPEDIA_URL" '{print NR, $0, url$0}'


### PR DESCRIPTION
nompediaのページ一覧を出力するコマンドを追加した．
具体的には，項番，タイトル，URLの一覧を出力する．

また，コマンドの追加に伴い，READMEに追記を行った．